### PR TITLE
Add MQTT for opening doors

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -1,0 +1,31 @@
+###############################################################################
+#
+# File: mqtt.py
+#
+# Author: Isaac Ingram
+#
+# Purpose: Provide MQTT facilities for the UI to send and receive data from the
+# cabinet.
+#
+###############################################################################
+import paho.mqtt.client as mqtt
+
+# TODO update broker URI with local broker
+broker = "mqtt://test.mosquitto.org"
+port = 1883
+open_doors_topic = "aux/control/doors"
+open_doors_msg = "open"
+
+client = mqtt.Client()
+client.connect(broker, port)
+
+def open_doors() -> bool:
+    """
+    Send a MQTT message to open the cabinet doors.
+
+    Returns:
+        bool: True if the message sent successfully, False otherwise.
+    """
+    result = client.publish(open_doors_topic, open_doors_msg)
+    status = result[0]
+    return status == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2024.8.30
 charset-normalizer==3.4.0
 idna==3.10
+paho-mqtt==2.1.0
 PySide6==6.7.3
 PySide6_Addons==6.7.3
 PySide6_Essentials==6.7.3


### PR DESCRIPTION
Implement MQTT to open the doors. Note that the URI for the MQTT broker will have to change once we have a local one instead of a testing one.