### PR TITLE
Refactor code to use ports defined in .env

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ Future main() async {
   await dotenv.load(fileName: ".env");
   KeepScreenOn.turnOn();
   if (Platform.isLinux) {
-    SerialService().startListening('/dev/ttyAMA0', baudRate: 9600);
+    SerialService().startListening(SerialService.portESP, baudRate: 9600);
 
     await windowManager.ensureInitialized();
     WindowOptions windowOptions = const WindowOptions(

--- a/lib/pages/admin.dart
+++ b/lib/pages/admin.dart
@@ -17,9 +17,8 @@ class _AdminPageState extends State<AdminPage> {
   StreamSubscription<SerialDataPacket>? _serialSubscription;
   @override
   void initState() {
-    const String espPort = '/dev/ttyAMA0';
     _serialSubscription = SerialService().dataStream
-        .where((packet) => packet.portName == espPort)
+        .where((packet) => packet.portName == SerialService.portESP)
         .listen((packet) {
           if (packet.protocol == SerialProtocol.json) {
             final Map<String, dynamic> jsonData =

--- a/lib/pages/cart.dart
+++ b/lib/pages/cart.dart
@@ -11,7 +11,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import '../services/uart.dart'; // Adjust path if needed
+import '../services/uart.dart';
 import 'dart:async';
 import 'dart:developer';
 
@@ -29,8 +29,6 @@ class _CartPageState extends State<CartPage> {
   StreamSubscription<SerialDataPacket>? _doorSubscription;
   StreamSubscription<SerialDataPacket>? _cartSubscription;
   User get user => widget.user;
-  final String espPort = '/dev/ttyAMA0';
-  final String jetsonPort = '/dev/ttyUSB0';
 
   @override
   void initState() {
@@ -39,21 +37,19 @@ class _CartPageState extends State<CartPage> {
   }
 
   void _initPorts() async {
-    const String jetsonPort = '/dev/ttyUSB0';
-
     bool success = await SerialService().startListening(
-      jetsonPort,
+      SerialService.portJetson,
       protocol: SerialProtocol.json,
     );
 
     if (!success) {
-      log("CartPage: FAILED to start listening on $jetsonPort");
+      log("CartPage: FAILED to start listening on $SerialService.portJetson");
     }
 
     _cartSubscription = SerialService().dataStream
         .where(
           (packet) =>
-              packet.portName == jetsonPort &&
+              packet.portName == SerialService.portJetson &&
               packet.protocol == SerialProtocol.json,
         )
         .listen((packet) {
@@ -70,22 +66,20 @@ class _CartPageState extends State<CartPage> {
           }
         });
 
-    const String espPort = '/dev/ttyAMA0';
-
     bool espSuccess = await SerialService().startListening(
-      espPort,
+      SerialService.portESP,
       protocol: SerialProtocol.json,
     );
 
     if (!espSuccess) {
-      log("CartPage: FAILED to start listening on $espPort");
+      log("CartPage: FAILED to start listening on $SerialService.portESP");
       return;
     }
 
     _doorSubscription = SerialService().dataStream
         .where(
           (packet) =>
-              packet.portName == espPort &&
+              packet.portName == SerialService.portESP &&
               packet.protocol == SerialProtocol.json,
         )
         .listen((packet) {

--- a/lib/pages/welcome.dart
+++ b/lib/pages/welcome.dart
@@ -37,23 +37,21 @@ class _WelcomePageState extends State<WelcomePage> {
   }
 
   void _initializeNfcListener() async {
-    const String nfcPort = '/dev/ttyUSB1';
-
     // 1. START the listener (opens the port, creates buffer)
     bool success = await SerialService().startListening(
-      nfcPort,
+      SerialService.portNFC,
       protocol: SerialProtocol.fixedLengthBinary,
       // Make sure this payloadSize matches your *expected incoming* packet size
       payloadSize: 7,
     );
 
     if (!success) {
-      log("WelcomePage: FAILED to start listening on $nfcPort");
+      log("WelcomePage: FAILED to start listening on $SerialService.portNFC");
       return;
     }
 
     _nfcSubscription = SerialService().dataStream
-        .where((packet) => packet.portName == nfcPort)
+        .where((packet) => packet.portName == SerialService.portNFC)
         .listen((packet) {
           if (packet.protocol == SerialProtocol.fixedLengthBinary) {
             log("NFC LISTENER recieved binary data");
@@ -75,7 +73,7 @@ class _WelcomePageState extends State<WelcomePage> {
 
     log("Sending NFC initialization command..."); // Added log
     SerialService().sendBinaryTo(
-      nfcPort,
+      SerialService.portNFC,
       // --- THIS IS YOUR NEW COMMAND ---
       Uint8List.fromList([0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
     );

--- a/lib/services/uart.dart
+++ b/lib/services/uart.dart
@@ -37,6 +37,10 @@ class SerialService {
   factory SerialService() => _instance;
   SerialService._internal();
 
+  static final String portESP = String.fromEnvironment("ESP_PORT", defaultValue: "/dev/ttyAMA0");
+  static final String portJetson = String.fromEnvironment("JETSON_PORT", defaultValue: "/dev/ttyUSB0");
+  static final String portNFC = String.fromEnvironment("NFC_PORT", defaultValue: "/dev/ttyUSB1");
+
   // Maps to hold separate resources for each port
   final Map<String, SerialPort> _ports = {};
   final Map<String, StreamSubscription> _subscriptions = {};


### PR DESCRIPTION
## What

This PR changes the random calls to the ESP, Jetson, and NFC to instead pull from the .env file.

## Why

Ensures the path is the same across calls, if the path ever needs to be changed you can change it in one spot instead of 5 different files.

## Test Plan

I plan to test this after it gets merged :)

## Env Vars

add:  `ESP_PORT='/dev/ttyAMA0'
JETSON_PORT='/dev/ttyUSB0'
NFC_PORT='/dev/ttyUSB0'`

## Documentation

Nope, lmk if I should

## Checklist

- [x] Tested all changes locally
