### PR TITLE
Port notifications

### DIFF
--- a/lib/components/admin_controls_grid.dart
+++ b/lib/components/admin_controls_grid.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import '../services/uart.dart';
+import '../services/serial_service.dart';
 import '../pages/welcome.dart';
 
 class AdminButton {

--- a/lib/components/log_overlay.dart
+++ b/lib/components/log_overlay.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:bits_n_bytes_ui/services/log_service.dart'; // Adjust path
-import 'package:bits_n_bytes_ui/services/uart.dart'; // Adjust path
+import 'package:bits_n_bytes_ui/services/serial_service.dart'; // Adjust path
 
 class HardwareStatusView extends StatefulWidget {
   const HardwareStatusView({super.key});

--- a/lib/components/log_overlay.dart
+++ b/lib/components/log_overlay.dart
@@ -35,9 +35,55 @@ class _HardwareStatusViewState extends State<HardwareStatusView> {
       padding: const EdgeInsets.all(20.0),
       child: Column(
         children: [
+          // Port Status Section
+          _sectionHeader("COMMUNICATION PORTS"),
           _connectionRow("ESP32 (Main Controller)", SerialService.portESP),
           _connectionRow("Jetson Nano (Vision)", SerialService.portJetson),
           _connectionRow("NFC Reader", SerialService.portNFC),
+          
+          const SizedBox(height: 20),
+          const Divider(color: Colors.white10),
+          const SizedBox(height: 10),
+
+          // New Shelf Status Section
+          _sectionHeader("ACTIVE SHELVES"),
+          Expanded(
+            child: ValueListenableBuilder<Map<String, dynamic>?>(
+              // Note the nullable type <Map<String, dynamic>?>
+              valueListenable: SerialService().espState, 
+              builder: (context, data, _) {
+                // 1. Handle Null or Empty Data
+                if (data == null || data.isEmpty) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.only(top: 20),
+                      child: Text(
+                        "WAITING FOR ESP32 DATA...", 
+                        style: TextStyle(color: Colors.white24, fontSize: 12, fontStyle: FontStyle.italic)
+                      ),
+                    ),
+                  );
+                }
+
+                // 2. Safely extract the list
+                final List<dynamic> shelfIds = data['shelf_ids'] ?? [];
+                
+                if (shelfIds.isEmpty) {
+                  return const Text("No shelves reported by ESP32", 
+                    style: TextStyle(color: Colors.white24, fontSize: 12));
+                }
+
+                // 3. Build the list if data is valid
+                return ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: shelfIds.length,
+                  itemBuilder: (context, index) {
+                    return _shelfRow(shelfIds[index].toString());
+                  },
+                );
+              },
+            ),
+          ),
           const Spacer(),
           SizedBox(
             width: double.infinity,
@@ -97,6 +143,37 @@ class _HardwareStatusViewState extends State<HardwareStatusView> {
                 fontWeight: FontWeight.bold
               ),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8.0),
+      child: Text(title, style: const TextStyle(color: Colors.greenAccent, fontSize: 10, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+    );
+  }
+
+  Widget _shelfRow(String shelfId) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          const Icon(Icons.shelves, size: 16, color: Colors.white54),
+          const SizedBox(width: 12),
+          Text(shelfId, style: const TextStyle(color: Colors.white, fontSize: 13)),
+          const Spacer(),
+          // Reusing your visual style for consistency
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.blueAccent.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: Colors.blueAccent.withOpacity(0.5)),
+            ),
+            child: const Text("ACTIVE", style: TextStyle(color: Colors.blueAccent, fontSize: 9, fontWeight: FontWeight.bold)),
           ),
         ],
       ),

--- a/lib/components/shelf.dart
+++ b/lib/components/shelf.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../services/uart.dart';
+import '../services/serial_service.dart';
 import 'dart:developer';
 
 class Shelf extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:device_preview/device_preview.dart';
 import 'pages/welcome.dart';
 import 'package:window_manager/window_manager.dart';
 import 'dart:io' show Platform;
-import '../services/uart.dart';
+import 'services/serial_service.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:keep_screen_on/keep_screen_on.dart';
 
@@ -69,7 +69,7 @@ class MyApp extends StatelessWidget {
     }
 
     return MouseRegion(
-      cursor: SystemMouseCursors.none,
+      cursor: (dotenv.env['HIDE_CURSOR'] == 'true') ? SystemMouseCursors.none : SystemMouseCursors.basic,
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
         theme: theme.light(),

--- a/lib/pages/admin.dart
+++ b/lib/pages/admin.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:bits_n_bytes_ui/components/admin_controls_grid.dart';
 import 'package:bits_n_bytes_ui/components/debug_action.dart';
 import 'package:bits_n_bytes_ui/components/debug_option.dart';
@@ -7,9 +5,8 @@ import 'package:bits_n_bytes_ui/components/log_overlay.dart';
 import 'package:bits_n_bytes_ui/components/shelf.dart';
 import 'package:bits_n_bytes_ui/services/log_service.dart';
 import 'package:flutter/material.dart';
-import 'package:lucide_icons_flutter/lucide_icons.dart';
-import '../services/uart.dart';
-import 'dart:async';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../services/serial_service.dart';
 
 class AdminPage extends StatefulWidget {
   const AdminPage({super.key});
@@ -69,7 +66,7 @@ class _AdminPageState extends State<AdminPage> {
     return DefaultTabController(
       length: 4,
       child: MouseRegion(
-        cursor: SystemMouseCursors.none,
+        cursor: (dotenv.env['HIDE_CURSOR'] == 'true') ? SystemMouseCursors.none : SystemMouseCursors.basic,
         child: Scaffold(
           body: SafeArea(
             child: Column(

--- a/lib/pages/cart.dart
+++ b/lib/pages/cart.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:async';
-import 'dart:developer';
 import 'package:bits_n_bytes_ui/services/log_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -14,7 +13,7 @@ import 'package:bits_n_bytes_ui/database/models/item.dart';
 import 'package:bits_n_bytes_ui/database/models/user.dart';
 import 'package:bits_n_bytes_ui/pages/door_closed.dart';
 import 'package:bits_n_bytes_ui/pages/welcome.dart';
-import '../services/uart.dart';
+import '../services/serial_service.dart';
 
 class CartPage extends StatefulWidget {
   final User user;

--- a/lib/pages/name.dart
+++ b/lib/pages/name.dart
@@ -1,6 +1,6 @@
 import 'package:bits_n_bytes_ui/database/models/user.dart';
 import 'package:bits_n_bytes_ui/pages/cart.dart';
-import 'package:bits_n_bytes_ui/services/uart.dart';
+import 'package:bits_n_bytes_ui/services/serial_service.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 

--- a/lib/pages/welcome.dart
+++ b/lib/pages/welcome.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:typed_data';
 import 'package:bits_n_bytes_ui/database/models/user.dart';
 import 'package:bits_n_bytes_ui/pages/admin.dart';
@@ -11,8 +10,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:virtual_keyboard_multi_language/virtual_keyboard_multi_language.dart';
-import '../services/uart.dart'; // Adjust path if needed
-import 'dart:async';
+import '../services/serial_service.dart'; // Adjust path if needed
 
 class WelcomePage extends StatefulWidget {
   const WelcomePage({super.key});

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
 
-import 'package:bits_n_bytes_ui/services/uart.dart';
+import 'package:bits_n_bytes_ui/services/serial_service.dart';
 import 'package:flutter/material.dart';
 
 /// Log Service

--- a/lib/services/serial_service.dart
+++ b/lib/services/serial_service.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'dart:typed_data'; // Required for Uint8List
+import 'package:bits_n_bytes_ui/services/serial_service_real.dart';
+import 'package:bits_n_bytes_ui/services/serial_service_sim.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+enum SerialProtocol {
+  /// Expects JSON objects wrapped in { ... }
+  json,
+
+  /// Expects fixed-length raw binary packets
+  fixedLengthBinary,
+}
+
+class SerialDataPacket {
+  final String portName;
+  final SerialProtocol protocol;
+  final dynamic
+  data; // Will be Map<String, dynamic> for JSON, Uint8List for binary
+
+  SerialDataPacket({
+    required this.portName,
+    required this.protocol,
+    required this.data,
+  });
+
+  @override
+  String toString() {
+    // This gives you a useful LogService.logEvent message when you print the object
+    return 'SerialDataPacket(port: $portName, protocol: $protocol, data: $data)';
+  }
+}
+
+abstract class SerialService {
+  static final String portESP = getPort("ESP_PORT", "/dev/ttyAMA0");
+  static final String portJetson = getPort("JETSON_PORT", "/dev/ttyUSB0");
+  static final String portNFC = getPort("NFC_PORT", "/dev/ttyUSB1");
+
+  // Common Notifiers
+  ValueNotifier<Map<String, dynamic>?> get espState;
+  ValueNotifier<Map<String, dynamic>?> get jetsonState;
+  ValueNotifier<Uint8List?> get nfcState;
+
+  Future<bool> startListening(String portName, {
+    int baudRate,
+    int payloadSize,
+    SerialProtocol protocol,
+  });
+  Future<bool> startListeningAll();
+  void sendJsonTo(String portName, Map<String, dynamic> data);
+  bool isListening(String portName);
+  void dispose();
+  void sendBinaryTo(String portName, Uint8List data);
+  void broadcastJson(Map<String, dynamic> data);
+  void stopListening(String portName);
+  void openDoors();
+  void openHatch();
+  Future<void> hardResetPort(String portName, {int baudRate = 9600});
+  Future<bool> startListeningNFC();
+  Future<bool> startListeningJetson();
+  Future<bool> startListeningESP();
+  
+  // Singleton accessor that handles the switch logic
+  static final SerialService _instance = _buildService();
+  factory SerialService() => _instance;
+
+  static SerialService _buildService() {
+    return (dotenv.env['SIM_CONNECTIONS'] == 'true') ? SerialServiceSim() : SerialServiceReal();
+  }
+
+  static String getPort(String envStr, String defaultVal) {
+    String? val = dotenv.env[envStr];
+    return (val != null) ? val : defaultVal;
+  }
+}

--- a/lib/services/serial_service_real.dart
+++ b/lib/services/serial_service_real.dart
@@ -1,70 +1,36 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:typed_data'; // Required for Uint8List
 import 'package:bits_n_bytes_ui/services/log_service.dart';
+import 'package:bits_n_bytes_ui/services/serial_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_libserialport/flutter_libserialport.dart';
 
-enum SerialProtocol {
-  /// Expects JSON objects wrapped in { ... }
-  json,
-
-  /// Expects fixed-length raw binary packets
-  fixedLengthBinary,
-}
-
-class SerialDataPacket {
-  final String portName;
-  final SerialProtocol protocol;
-  final dynamic
-  data; // Will be Map<String, dynamic> for JSON, Uint8List for binary
-
-  SerialDataPacket({
-    required this.portName,
-    required this.protocol,
-    required this.data,
-  });
-
-  @override
-  String toString() {
-    // This gives you a useful LogService.logEvent message when you print the object
-    return 'SerialDataPacket(port: $portName, protocol: $protocol, data: $data)';
-  }
-}
-
-class SerialService {
-  // Singleton remains to provide a central access point
-  static final SerialService _instance = SerialService._internal();
-  factory SerialService() => _instance;
-  SerialService._internal();
-
-  static final String portESP = String.fromEnvironment("ESP_PORT", defaultValue: "/dev/ttyAMA0");
-  static final String portJetson = String.fromEnvironment("JETSON_PORT", defaultValue: "/dev/ttyUSB0");
-  static final String portNFC = String.fromEnvironment("NFC_PORT", defaultValue: "/dev/ttyUSB1");
-
+class SerialServiceReal implements SerialService {
   // Maps to hold separate resources for each port
   final Map<String, SerialPort> _ports = {};
   final Map<String, StreamSubscription> _subscriptions = {};
 
   final Map<String, String> _jsonBuffers = {}; // For JSON string data
   final Map<String, Uint8List> _binaryBuffers = {}; // For raw binary data
-  final Map<String, int> _binaryPayloadSizes =
-      {}; // Stores PAYLOAD_SIZE for binary ports
-  final Map<String, SerialProtocol> _portProtocols =
-      {}; // Stores protocol for each port
+  final Map<String, int> _binaryPayloadSizes = {}; // Stores PAYLOAD_SIZE for binary ports
+  final Map<String, SerialProtocol> _portProtocols = {}; // Stores protocol for each port
 
   final Map<String, BytesBuilder> _binaryBuilders = {};
 
+  @override
   final ValueNotifier<Map<String, dynamic>?> espState = ValueNotifier(null);
+  @override
   final ValueNotifier<Map<String, dynamic>?> jetsonState = ValueNotifier(null);
+  @override
   final ValueNotifier<Uint8List?> nfcState = ValueNotifier(null);
 
+  @override
   Future<bool> startListening(
     String portName, {
     int baudRate = 9600,
     SerialProtocol protocol = SerialProtocol.json,
-    int payloadSize = 0, // REQUIRED for fixedLengthBinary
+    int payloadSize = 0,
   }) async {
     if (_ports.containsKey(portName)) {
       LogService.logEvent("SerialService: Already listening on $portName");
@@ -187,11 +153,11 @@ void _onJsonDataReceived(String portName, Uint8List data) {
       LogService.logEvent("JSON COMPLETE SENDING");
       final Map<String, dynamic> jsonData = jsonDecode(completeJson);
 
-      if (portName == portESP) {
+      if (portName == SerialService.portESP) {
         // This updates the value and NOTIFIES all listeners automatically
         espState.value = jsonData;
         LogService.logEvent("onJsonDataReceived: ESP");
-      } else if (portName == portJetson) {
+      } else if (portName == SerialService.portJetson) {
         jetsonState.value = jsonData;
         // LogService.logEvent("onJsonDataReceived: JETSON");
       // } else if (portName == portNFC) { // NFC SHOULDNT BE CALLED HERE
@@ -225,7 +191,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
       final remainder = fullBuffer.sublist(payloadSize);
       
       // _dataStreamController.add(SerialDataPacket(portName: portName, protocol: SerialProtocol.json, data: packet));
-      if (portName == portNFC) {
+      if (portName == SerialService.portNFC) {
         nfcState.value = packet;
         LogService.logEvent("onBinaryDataReceived: NFC packet updated");
       } else {
@@ -239,6 +205,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
   // --- Sending Methods ---
 
   /// Send a JSON object to a specific port
+  @override
   void sendJsonTo(String portName, Map<String, dynamic> data) {
     final port = _ports[portName];
     if (port == null || !port.isOpen) {
@@ -254,6 +221,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
   }
 
   /// Send raw binary data (a Uint8List) to a specific port
+  @override
   void sendBinaryTo(String portName, Uint8List data) {
     final port = _ports[portName];
     if (port == null || !port.isOpen) {
@@ -269,6 +237,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
   }
 
   /// Send JSON to ALL known ports
+  @override
   void broadcastJson(Map<String, dynamic> data) {
     for (final portName in _ports.keys) {
       if (_portProtocols[portName] == SerialProtocol.json) {
@@ -277,6 +246,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     }
   }
 
+  @override
   void stopListening(String portName) {
     if (_ports.containsKey(portName)) {
       LogService.logEvent("SerialService: Stopping listener and cleaning up $portName...");
@@ -286,6 +256,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     }
   }
 
+  @override
   bool isListening(String portName) {
     return _ports.containsKey(portName);
   }
@@ -304,6 +275,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     _binaryPayloadSizes.remove(portName);
   }
 
+  @override
   void dispose() {
     for (var portName in _ports.keys.toList()) {
       _cleanupPort(portName);
@@ -313,16 +285,19 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     nfcState.dispose();
   }
 
+  @override
   void openDoors() {
     LogService.logEvent("Sending door command...");
-    sendJsonTo(portESP, {"doors": true,"hatch":false});
+    sendJsonTo(SerialService.portESP, {"doors": true,"hatch":false});
   }
 
+  @override
   void openHatch() {
     LogService.logEvent("Sending hatch command...");
-    sendJsonTo(portESP, {"hatch": true,"doors":false});
+    sendJsonTo(SerialService.portESP, {"hatch": true,"doors":false});
   }
 
+  @override
   Future<void> hardResetPort(String portName, {int baudRate = 9600}) async {
     LogService.logEvent("SerialService: Hard resetting $portName...");
 
@@ -347,6 +322,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     await startListening(portName, baudRate: baudRate);
   }
 
+  @override
   Future<bool> startListeningNFC() async {
     bool success = await startListening(
       SerialService.portNFC,
@@ -363,6 +339,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     return success;
   }
 
+  @override
   Future<bool> startListeningJetson() async {
     bool success = await startListening(
       SerialService.portJetson,
@@ -378,6 +355,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     return success;
   }
 
+  @override
   Future<bool> startListeningESP() async {
     bool success = await startListening(
       SerialService.portESP,
@@ -393,6 +371,7 @@ void _onJsonDataReceived(String portName, Uint8List data) {
     return success;
   }
 
+  @override
   Future<bool> startListeningAll() async {
     LogService.logEvent("UART-Service: StartListeningAll");
     // Start all of them simultaneously

--- a/lib/services/serial_service_sim.dart
+++ b/lib/services/serial_service_sim.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_router/shelf_router.dart';
+import 'package:bits_n_bytes_ui/services/log_service.dart';
+import 'package:bits_n_bytes_ui/services/serial_service.dart';
+import 'package:flutter/material.dart' hide Router;
+
+class SerialServiceSim implements SerialService {
+  @override
+  final ValueNotifier<Map<String, dynamic>?> espState = ValueNotifier(null);
+  @override
+  final ValueNotifier<Map<String, dynamic>?> jetsonState = ValueNotifier(null);
+  @override
+  final ValueNotifier<Uint8List?> nfcState = ValueNotifier(null);
+
+  HttpServer? _server;
+
+  @override
+  Future<bool> startListeningAll() async {
+    LogService.logEvent("UART-Service: Starting Simulator REST API...");
+    
+    final router = Router();
+
+    // PUT /esp
+    // {
+    // 	"doors": true,
+    // 	"hatch": true,
+    // 	"temp_c": 56,
+    // 	"intake_rpm": 1000,
+    // 	"exhaust_rmp": 1000,
+    // 	"shelf_ids": ["MAC_1", "MAC_2", "MAC_3"]
+    // }
+    router.put('/esp', (Request request) async {
+      try {
+        final content = await request.readAsString();
+        final data = jsonDecode(content) as Map<String, dynamic>;
+        espState.value = data;
+        LogService.logEvent("Sim: ESP state updated via PUT");
+        return Response.ok(jsonEncode({'status': 'success', 'received': data}));
+      } catch (e) {
+        return Response.internalServerError(body: 'JSON Parse Error: $e');
+      }
+    });
+
+    // PUT /jetson
+    router.put('/jetson', (Request request) async {
+      try {
+        final content = await request.readAsString();
+        final data = jsonDecode(content) as Map<String, dynamic>;
+        jetsonState.value = data;
+        LogService.logEvent("Sim: Jetson state updated via PUT");
+        return Response.ok(jsonEncode({'status': 'success', 'received': data}));
+      } catch (e) {
+        return Response.internalServerError(body: 'JSON Parse Error: $e');
+      }
+    });
+
+    // NFC remains unimplemented as requested
+    router.put('/nfc', (Request request) {
+      return Response.notFound('NFC simulation not implemented yet');
+    });
+
+    try {
+      // Binding to 0.0.0.0 allows access from other devices on the network
+      _server = await io.serve(router, '0.0.0.0', 8080);
+      LogService.logEvent("🚀 Sim Server running at http://${_server!.address.host}:${_server!.port}");
+      return true;
+    } catch (e) {
+      LogService.logEvent("Sim Server failed to start: $e");
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> startListening(
+    String portName, {
+    int baudRate = 9600,
+    SerialProtocol protocol = SerialProtocol.json,
+    int payloadSize = 0,
+  }) async => true;
+
+  @override
+  void sendJsonTo(String portName, Map<String, dynamic> data) {
+    LogService.logEvent("SIM OUTBOUND [$portName]: ${jsonEncode(data)}");
+  }
+
+  @override
+  void sendBinaryTo(String portName, Uint8List data) {
+    LogService.logEvent("SIM OUTBOUND BINARY [$portName]: ${data.length} bytes");
+  }
+
+  @override
+  void broadcastJson(Map<String, dynamic> data) {
+    sendJsonTo("BROADCAST", data);
+  }
+
+  @override
+  bool isListening(String portName) => _server != null;
+
+  @override
+  void stopListening(String portName) => LogService.logEvent("Sim: Stop listening $portName");
+
+  @override
+  void dispose() {
+    _server?.close();
+    espState.dispose();
+    jetsonState.dispose();
+    nfcState.dispose();
+  }
+
+  // Helper logic for UI buttons
+  @override
+  void openDoors() => sendJsonTo(SerialService.portESP, {"doors": true, "hatch": false});
+  
+  @override
+  void openHatch() => sendJsonTo(SerialService.portESP, {"hatch": true, "doors": false});
+
+  @override
+  Future<void> hardResetPort(String portName, {int baudRate = 9600}) async {
+    LogService.logEvent("Sim: Hard reset triggered for $portName");
+  }
+
+  // These are kept to satisfy the interface, though startListeningAll handles the server
+  @override
+  Future<bool> startListeningNFC() async => true;
+  @override
+  Future<bool> startListeningJetson() async => true;
+  @override
+  Future<bool> startListeningESP() async => true;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -197,6 +197,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_parser:
     dependency: transitive
     description:
@@ -289,18 +297,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -517,6 +525,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shelf:
+    dependency: "direct main"
+    description:
+      name: shelf
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
+  shelf_router:
+    dependency: "direct main"
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -614,10 +638,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   flutter_dotenv: ^6.0.0
   keep_screen_on: ^5.0.0
   redis: ^4.0.0
+  shelf: ^1.4.2
+  shelf_router: ^1.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## What

Adds Shelves to Hardware Tab in log overlay.
Adds a basic data Sim for the ESP and Jetson through REST API to test changes locally easier
Adds a way to hide the cursor

## Why

Seeing current state of shelves is nice
Sim proved the UI changes with the LOG work
Because the cursor being hidden is super annoying

## Test Plan

I built it and ran it, and looked at it, and tested it with Postman

## Env Vars

Both should be false when running on the PI
SIM_CONNECTIONS
HIDE_CURSOR

## Documentation

Nope, I probably messed with something though or should write docs on it idk

## Checklist

- [yes] Tested all changes locally
